### PR TITLE
0.6.0

### DIFF
--- a/lib/commands/compile.js
+++ b/lib/commands/compile.js
@@ -184,17 +184,15 @@ exports.compile = function (opt, callback) {
                     logger.info('using almond.js');
                     impl = path.relative(
                         path.resolve(opt.baseurl),
-                        path.resolve(__dirname,
-                            '../../node_modules/almond/almond'
-                        )
+                        require.resolve('almond')
                     );
                 }
                 else {
+                    var require_path = require.resolve('requirejs');
+
                     impl = path.relative(
                         path.resolve(opt.baseurl),
-                        path.resolve(__dirname,
-                            '../../node_modules/requirejs/require'
-                        )
+                        path.join(require_path, '../../require.js')
                     );
                 }
 

--- a/lib/project.js
+++ b/lib/project.js
@@ -146,9 +146,12 @@ exports.writeMeta = function (package_dir, data, callback) {
 
 // adds RequireJS to project directory
 exports.makeRequireJS = function (package_dir, config, callback) {
-    var source = path.resolve(__dirname,'../node_modules/requirejs/require.js');
+    var require_path = require.resolve('requirejs');
+    var source = path.join(require_path, '../../require.js')
     var dest = path.resolve(package_dir, 'require.js');
+
     logger.info('updating', path.relative(process.cwd(), dest));
+
     fs.readFile(source, function (err, content) {
         if (err) {
             return callback(err);
@@ -249,7 +252,7 @@ exports.updateRequireConfig = function (package_dir, baseurl, /*opt*/rcfg, callb
                 version: version,
                 shim: shims
             }
-            
+
             // now bring in other require.config.js options to make available
             // earlier versions had variable substitution that breaks on r.js compilation
             // now there is duplication - however, the original jam has been left untouched.
@@ -257,7 +260,7 @@ exports.updateRequireConfig = function (package_dir, baseurl, /*opt*/rcfg, callb
             cfg.packages = _.union(rcfg.packages || [], packages);
             cfg.shim = _.extend({}, rcfg.shim || {}, shims);
             var configStr = JSON.stringify(cfg, null, 4);
-            
+
             var src = 'var jam = ' + JSON.stringify(data, null, 4) + ';\n' +
                 '\n' +
                 'if (typeof require !== "undefined" && require.config) {\n' +
@@ -271,7 +274,7 @@ exports.updateRequireConfig = function (package_dir, baseurl, /*opt*/rcfg, callb
                     'typeof module !== "undefined") {\n' +
                 '    module.exports = jam;\n' +
                 '}';
-            
+
             var filename = path.resolve(package_dir, 'require.config.js');
             mkdirp(package_dir, function (err) {
                 if (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamjs",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "",
   "maintainers": [
     {
@@ -13,7 +13,6 @@
     }
   ],
   "dependencies": {
-    "almond": "0.2.5",
     "async": "~0.1.21",
     "chance": "^0.7.3",
     "fstream": "~0.1.18",
@@ -27,16 +26,19 @@
     "ncp": "~0.2.6",
     "prompt": "0.2.1",
     "request": "~2.9.202",
-    "requirejs": "2.1.4",
     "rimraf": "~2.0.1",
     "schinquirer": "^0.1.1",
     "semver": "~4.3.3",
     "tar": "~0.1.13",
     "underscore": "~1.8.3"
   },
+  "peerDependencies": {
+    "requirejs": "2.1.4",
+    "almond": "0.2.5"
+  },
   "devDependencies": {
     "cuculus": "^0.3.3",
-    "nodeunit": "0.9.1",
+    "nodeunit": "0.7.4",
     "sinon": "^1.14.1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamjs",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "",
   "maintainers": [
     {
@@ -13,7 +13,6 @@
     }
   ],
   "dependencies": {
-    "almond": "0.2.5",
     "async": "~0.1.21",
     "chance": "^0.7.3",
     "fstream": "~0.1.18",
@@ -27,12 +26,15 @@
     "ncp": "~0.2.6",
     "prompt": "0.2.1",
     "request": "~2.9.202",
-    "requirejs": "2.1.4",
     "rimraf": "~2.0.1",
     "schinquirer": "^0.1.1",
     "semver": "~4.3.3",
     "tar": "~0.1.13",
     "underscore": "~1.8.3"
+  },
+  "peerDependencies": {
+    "requirejs": "2.1.4",
+    "almond": "0.2.5"
   },
   "devDependencies": {
     "cuculus": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamjs",
-  "version": "0.6.0",
+  "version": "0.5.4",
   "description": "",
   "maintainers": [
     {
@@ -13,6 +13,7 @@
     }
   ],
   "dependencies": {
+    "almond": "0.2.5",
     "async": "~0.1.21",
     "chance": "^0.7.3",
     "fstream": "~0.1.18",
@@ -26,19 +27,16 @@
     "ncp": "~0.2.6",
     "prompt": "0.2.1",
     "request": "~2.9.202",
+    "requirejs": "2.1.4",
     "rimraf": "~2.0.1",
     "schinquirer": "^0.1.1",
     "semver": "~4.3.3",
     "tar": "~0.1.13",
     "underscore": "~1.8.3"
   },
-  "peerDependencies": {
-    "requirejs": "2.1.4",
-    "almond": "0.2.5"
-  },
   "devDependencies": {
     "cuculus": "^0.3.3",
-    "nodeunit": "0.7.4",
+    "nodeunit": "0.9.1",
     "sinon": "^1.14.1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamjs",
-  "version": "0.6.0",
+  "version": "0.5.4",
   "description": "",
   "maintainers": [
     {
@@ -13,6 +13,7 @@
     }
   ],
   "dependencies": {
+    "almond": "0.3.1",
     "async": "~0.1.21",
     "chance": "^0.7.3",
     "fstream": "~0.1.18",
@@ -26,19 +27,16 @@
     "ncp": "~0.2.6",
     "prompt": "0.2.1",
     "request": "~2.9.202",
+    "requirejs": "2.1.20",
     "rimraf": "~2.0.1",
     "schinquirer": "^0.1.1",
     "semver": "~4.3.3",
     "tar": "~0.1.13",
     "underscore": "~1.8.3"
   },
-  "peerDependencies": {
-    "requirejs": "2.1.4",
-    "almond": "0.2.5"
-  },
   "devDependencies": {
     "cuculus": "^0.3.3",
-    "nodeunit": "0.7.4",
+    "nodeunit": "0.9.1",
     "sinon": "^1.14.1"
   },
   "repository": {
@@ -46,7 +44,7 @@
     "url": "http://github.com/caolan/jam.git"
   },
   "engines": {
-    "node": ">= 0.6.x"
+    "node": ">= 0.12.2"
   },
   "bugs": {
     "url": "http://github.com/caolan/jam/issues"


### PR DESCRIPTION
1. `requirejs` и `almond` отправлены в `peerDependencies` и `devDependencies`
2. Путь к `requirejs` и `almond` теперь резолвится относительно директории модуля, что позволяет использовать npm 3
