### PR TITLE
url.format() slashes fix

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -629,7 +629,7 @@ exports.get = (function() {
                     switch (uriParsed.protocol) {
                         case "ssh:": {
 
-                            uriCloneConfig = _.pick(uriParsed, [ "host", "auth" ]);
+                            uriCloneConfig = _.pick(uriParsed, [ "protocol", "slashes", "host", "auth" ]);
 
                             // project path could be divided by `:` or `/`
                             if (uriParsed.pathname.indexOf(":") == -1) {
@@ -643,7 +643,7 @@ exports.get = (function() {
                                 return;
                             }
 
-                            uriClone = uriParsed.protocol + url.format(uriCloneConfig) + '/' + sshProject;
+                            uriClone = url.format(uriCloneConfig) + '/' + sshProject;
                             break;
                         }
 


### PR DESCRIPTION
В 7 ноде изменили поведение в url.format: https://github.com/nodejs/node/pull/7234
Тут правка в документации: https://github.com/nodejs/node/pull/9731
